### PR TITLE
Add migration to make installation ids mandatory (not nullable).

### DIFF
--- a/services/backend/src/db/migrations/20200724230127_update-installation-ids.js
+++ b/services/backend/src/db/migrations/20200724230127_update-installation-ids.js
@@ -1,0 +1,13 @@
+exports.up = async (knex) => {
+    // Add notNullable constraint on the installation_id column
+    await knex.schema.alterTable('repositories', (table) => {
+        table.string('installation_id').notNullable().alter();
+    });
+};
+
+exports.down = async (knex) => {
+    // Remove notNullable constraint on the installation_id column
+    await knex.schema.alterTable('repositories', (table) => {
+        table.string('installation_id').nullable().alter();
+    });
+};


### PR DESCRIPTION
**Related Task**: https://github.com/BlockedTODO/BlockedTODO/issues/183

Run the `addGitHubInstallationIds.js` job in production, and then merge this commit.