### PR TITLE
ECMAScript modules frontend servers

### DIFF
--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -49,5 +49,6 @@
     "test": "CI=true react-scripts test",
     "test:watch": "react-scripts test"
   },
+  "type": "module",
   "version": "1.0.0"
 }

--- a/services/frontend/server/app.js
+++ b/services/frontend/server/app.js
@@ -13,15 +13,17 @@
  * In short, there are three relevant files: server/app.js, public/index.html, and src/utils/environment.js
  *
  */
-const express = require('express');
-const fs = require('fs');
-const morgan = require('morgan');
-const path = require('path');
+import express from 'express';
+import fs from 'fs';
+import morgan from 'morgan';
+import path from 'path';
+import {fileURLToPath} from 'url';
 
+const parentFolder = path.dirname(fileURLToPath(import.meta.url))
 const app = express();
 
 const renderApp = (req, res) => {
-    const filePath = path.resolve(__dirname, '..', 'build', 'index.html');
+    const filePath = path.resolve(parentFolder, '..', 'build', 'index.html');
 
     fs.readFile(filePath, 'utf8', (error, htmlData) => {
         if (error) {
@@ -39,7 +41,7 @@ const renderApp = (req, res) => {
 
 app.use(morgan(':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] :response-time ms'));
 app.get('/', renderApp);
-app.use(express.static(path.resolve(__dirname, '..', 'build')));
+app.use(express.static(path.resolve(parentFolder, '..', 'build')));
 app.get('*', renderApp);
 
-module.exports = app;
+export default app;

--- a/services/frontend/server/index.js
+++ b/services/frontend/server/index.js
@@ -1,6 +1,5 @@
-'use strict';
+import app from './app.js';
 
-const app = require('./app');
 const PORT = parseInt(process.env.PORT) || 3001;
 
 app.listen(PORT, () => {

--- a/services/website/package.json
+++ b/services/website/package.json
@@ -42,5 +42,6 @@
     "test": "CI=true react-scripts test",
     "test:watch": "react-scripts test"
   },
+  "type": "module",
   "version": "1.0.0"
 }

--- a/services/website/server/app.js
+++ b/services/website/server/app.js
@@ -13,15 +13,18 @@
  * In short, there are three relevant files: server/app.js, public/index.html, and src/utils/environment.js
  *
  */
-const express = require('express');
-const fs = require('fs');
-const morgan = require('morgan');
-const path = require('path');
+import express from 'express';
+import fs from 'fs';
+import morgan from 'morgan';
+import path from 'path';
+import {fileURLToPath} from 'url';
 
+const parentFolder = path.dirname(fileURLToPath(import.meta.url))
 const app = express();
 
 const renderApp = (req, res) => {
-    const filePath = path.resolve(__dirname, '..', 'build', 'index.html');
+    const filePath = path.resolve(parentFolder, '..', 'build', 'index.html');
+    console.log(filePath);
 
     fs.readFile(filePath, 'utf8', (error, htmlData) => {
         if (error) {
@@ -39,7 +42,7 @@ const renderApp = (req, res) => {
 
 app.use(morgan(':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] :response-time ms'));
 app.get('/', renderApp);
-app.use(express.static(path.resolve(__dirname, '..', 'build')));
+app.use(express.static(path.resolve(parentFolder, '..', 'build')));
 app.get('*', renderApp);
 
-module.exports = app;
+export default app;

--- a/services/website/server/index.js
+++ b/services/website/server/index.js
@@ -1,6 +1,5 @@
-'use strict';
+import app from './app.js';
 
-const app = require('./app');
 const PORT = parseInt(process.env.PORT) || 3002;
 
 app.listen(PORT, () => {


### PR DESCRIPTION
I want to use the same import/export syntax within each service.

Eventually, I'd like to do the backend service as well, but currently jest only has [experimental support](https://jestjs.io/docs/ecmascript-modules) for ECMAScript modules so I'm going to wait for better support on that front.