### PR TITLE
Migrate backend server to ECMAScript Module

### DIFF
--- a/services/backend/.eslintrc
+++ b/services/backend/.eslintrc
@@ -94,6 +94,10 @@
             {
                 "allowSingleLine": true
             }
+        ],
+        "comma-dangle": [
+            "error",
+            "only-multiline"
         ]
     }
 }

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -13,9 +13,6 @@ RUN bash -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update && apt-get install -y postgresql-client
 
-# Source run-time environment variables
-ENV NODE_PATH=src
-
 # Expose ports in the container
 EXPOSE 3000
 EXPOSE 80

--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -5,7 +5,6 @@ Exposes a GraphQL API.
 # Required environment variables
 Most of these are automatically set when running with docker-compose, but all do need to be set manually on production environments
 
-* `NODE_PATH=src`
 * `DATABASE_NAME`
 * `DATABASE_USER`
 * `DATABASE_PASSWORD`

--- a/services/backend/jest.config.js
+++ b/services/backend/jest.config.js
@@ -1,7 +1,7 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
-module.exports = {
+const jestConfig = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 
@@ -21,7 +21,7 @@ module.exports = {
   // collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: "coverage",
+  coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
   // coveragePathIgnorePatterns: [
@@ -129,7 +129,7 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: "node",
+  testEnvironment: 'node',
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},
@@ -157,6 +157,9 @@ module.exports = {
   // This option allows use of a custom test runner
   // testRunner: "jasmine2",
 
+  // Default timeout of a test in milliseconds
+  testTimeout: 8000,
+
   // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
   // testURL: "http://localhost",
 
@@ -164,7 +167,7 @@ module.exports = {
   // timers: "real",
 
   // A map from regular expressions to paths to transformers
-  // transform: undefined,
+  transform: {}, // For support for ECMAScript Modules, as per https://jestjs.io/docs/ecmascript-modules
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   // transformIgnorePatterns: [
@@ -183,3 +186,5 @@ module.exports = {
   // Whether to use watchman for file crawling
   // watchman: true,
 };
+
+export default jestConfig;

--- a/services/backend/package-lock.json
+++ b/services/backend/package-lock.json
@@ -5768,7 +5768,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gtoken": {
       "version": "5.2.1",
@@ -6414,6 +6415,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -8228,6 +8230,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -8242,6 +8245,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -8251,6 +8255,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -8259,7 +8264,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9677,7 +9683,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -56,7 +56,8 @@
     "bot"
   ],
   "license": "Prosperity Public License 3.0.0",
-  "main": "src/index.js",
+  "type": "module",
+  "exports": "./src/index.js",
   "name": "backend",
   "repository": {
     "type": "git",
@@ -71,8 +72,8 @@
     "start": "nodemon src/",
     "start:debug": "nodemon --inspect=0.0.0.0:9229 src/",
     "start:prod": "node src/",
-    "test": "NODE_ENV=test jest",
-    "test:watch": "NODE_ENV=test jest --watchAll"
+    "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --watchAll"
   },
   "version": "1.0.0"
 }

--- a/services/backend/repl.js
+++ b/services/backend/repl.js
@@ -1,8 +1,8 @@
 /* A repl server for BlockedTODO.
  * It behaves in a similar manner to rails console.
  * Run with `node --experimental-repl-await ./repl.js` */
-const repl = require('repl');
-const db = require('db/');
+import repl from 'repl';
+import knex, * as models from './src/db/index.js';
 
 // Helper methods to add in the context of the repl
 const getOwnMethods = (object) => {
@@ -44,7 +44,8 @@ const replServer = repl.start({
 
 // Import in the context of the repl server
 Object.assign(replServer.context, {
-    ...db,
+    knex,
+    ...models,
     printDepth,
     getOwnMethods,
     getAllMethods,

--- a/services/backend/src/app.js
+++ b/services/backend/src/app.js
@@ -1,11 +1,11 @@
-const express = require('express');
-const cors = require('cors');
-const cookieParser = require('cookie-parser');
-const morgan = require('morgan');
-const apolloServer = require('graphql/apolloServer');
-const {errorHandler, passport, sessions} = require('middleware/');
-const githubWebhooks = require('github/webhooks');
-const {authRouter, githubRouter} = require('routes/');
+import express from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+import cookieParser from 'cookie-parser';
+import apolloServer from './graphql/apolloServer.js';
+import {errorHandler, passport, sessions} from './middleware/index.js';
+import githubWebhooks from './github/webhooks/index.js';
+import {authRouter, githubRouter} from './routes/index.js';
 
 const app = express();
 
@@ -40,4 +40,4 @@ if (process.env.GRAPHQL_API_ENABLED === 'true') {
     apolloServer.applyMiddleware({app});
 }
 
-module.exports = app;
+export default app;

--- a/services/backend/src/db/config/knexfile.js
+++ b/services/backend/src/db/config/knexfile.js
@@ -1,6 +1,8 @@
-const {knexSnakeCaseMappers} = require('objection');
+import objection from 'objection';
 
-module.exports = {
+const {knexSnakeCaseMappers} = objection;
+
+const knexConfig = {
     development: {
         client: 'postgresql',
         connection: {
@@ -74,3 +76,5 @@ module.exports = {
         ...knexSnakeCaseMappers(),
     }
 };
+
+export default knexConfig;

--- a/services/backend/src/db/index.js
+++ b/services/backend/src/db/index.js
@@ -1,10 +1,11 @@
 /* BlockedTODO: https://github.com/knex/knex/issues/3866
  * Upgrade knex and use absolute imports all over the db/ folder once it's closed */
-const {Model} = require('objection');
-const Knex = require('knex');
-const knexConfig = require('./config/knexfile');
-const logger = require('../utils/logger');
-const models = require('./models');
+import {Model} from 'objection';
+import Knex from 'knex';
+import knexConfig from './config/knexfile.js';
+import {logger} from '../utils/index.js';
+
+export * from './models/index.js'; // Export all models
 
 const environment = process.env.NODE_ENV || 'development';
 const knex = Knex(knexConfig[environment]);
@@ -13,7 +14,4 @@ knex.on('query', (data) => logger.info(`${data.sql} -- Bindings: ${data.bindings
 // Bind all Models to a knex instance.
 Model.knex(knex);
 
-module.exports = {
-    knex,
-    ...models,
-};
+export default knex;

--- a/services/backend/src/db/migrations/20200520004000_create-user.js
+++ b/services/backend/src/db/migrations/20200520004000_create-user.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.createTable('users', (table) => {
         table.uuid('id').primary().notNullable();
         table.string('email').notNullable().unique();
@@ -10,6 +10,6 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.dropTableIfExists('users');
 };

--- a/services/backend/src/db/migrations/20200520004912_create-repository.js
+++ b/services/backend/src/db/migrations/20200520004912_create-repository.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.createTable('repositories', (table) => {
         table.uuid('id').primary().notNullable();
         table.string('host').notNullable();
@@ -10,6 +10,6 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.dropTableIfExists('repositories');
 };

--- a/services/backend/src/db/migrations/20200521045438_create-issue.js
+++ b/services/backend/src/db/migrations/20200521045438_create-issue.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.createTable('issues', (table) => {
         table.uuid('id').primary().notNullable();
         table.string('url').notNullable().unique();
@@ -9,6 +9,6 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.dropTableIfExists('issues');
 };

--- a/services/backend/src/db/migrations/20200521050527_create-task.js
+++ b/services/backend/src/db/migrations/20200521050527_create-task.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.createTable('tasks', (table) => {
         table.uuid('id').primary().notNullable();
         table.string('host').notNullable();
@@ -10,6 +10,6 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.dropTableIfExists('tasks');
 };

--- a/services/backend/src/db/migrations/20200521054925_add-task-associations.js
+++ b/services/backend/src/db/migrations/20200521054925_add-task-associations.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.table('tasks', (table) => {
         table.uuid('repository_id').references('id').inTable('repositories').onDelete('CASCADE').onUpdate('CASCADE').notNullable(); // eslint-disable-line
         table.uuid('issue_id').references('id').inTable('issues').onDelete('CASCADE').onUpdate('CASCADE').notNullable();
@@ -10,7 +10,7 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.table('tasks', (table) => {
         table.dropColumn('repository_id');
         table.dropColumn('issue_id');

--- a/services/backend/src/db/migrations/20200521063246_add-issue-repository-associations.js
+++ b/services/backend/src/db/migrations/20200521063246_add-issue-repository-associations.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.createTable('repository_issues', (table) => {
         table.uuid('repository_id').references('id').inTable('repositories').onDelete('CASCADE').onUpdate('CASCADE').notNullable(); // eslint-disable-line
         table.uuid('issue_id').references('id').inTable('issues').onDelete('CASCADE').onUpdate('CASCADE').notNullable();
@@ -10,6 +10,6 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.dropTableIfExists('repository_issues');
 };

--- a/services/backend/src/db/migrations/20200521122223_add-repository-user-associations.js
+++ b/services/backend/src/db/migrations/20200521122223_add-repository-user-associations.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.createTable('user_repositories', (table) => {
         table.uuid('user_id').references('id').inTable('users').onDelete('CASCADE').onUpdate('CASCADE').notNullable();
         table.uuid('repository_id').references('id').inTable('repositories').onDelete('CASCADE').onUpdate('CASCADE').notNullable(); // eslint-disable-line
@@ -10,6 +10,6 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.dropTableIfExists('user_repositories');
 };

--- a/services/backend/src/db/migrations/20200715213931_update-issue-repository-associations.js
+++ b/services/backend/src/db/migrations/20200715213931_update-issue-repository-associations.js
@@ -1,7 +1,7 @@
-const {v4: uuidv4} = require('uuid');
+import {v4 as uuidv4} from 'uuid';
 
 // Convert repository-issue relation from many-to-many to one-to-many
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.table('issues', (table) => {
         // Remove uniqueness constraint on issue urls
         table.dropUnique('url');
@@ -43,7 +43,7 @@ exports.up = async (knex) => {
     await knex.schema.dropTableIfExists('repository_issues');
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     // Recreate repository_issues join table
     await knex.schema.createTable('repository_issues', (table) => {
         table.uuid('repository_id').references('id').inTable('repositories').onDelete('CASCADE').onUpdate('CASCADE').notNullable(); // eslint-disable-line

--- a/services/backend/src/db/migrations/20200719073837_add-installation-ids.js
+++ b/services/backend/src/db/migrations/20200719073837_add-installation-ids.js
@@ -1,11 +1,11 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.table('repositories', (table) => {
         // Add installation_id column
         table.string('installation_id');
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.table('repositories', (table) => {
         // Remove installation_id column
         table.dropColumn('installation_id');

--- a/services/backend/src/db/migrations/20200724230127_update-installation-ids.js
+++ b/services/backend/src/db/migrations/20200724230127_update-installation-ids.js
@@ -1,11 +1,11 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     // Add notNullable constraint on the installation_id column
     await knex.schema.alterTable('repositories', (table) => {
         table.string('installation_id').notNullable().alter();
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     // Remove notNullable constraint on the installation_id column
     await knex.schema.alterTable('repositories', (table) => {
         table.string('installation_id').nullable().alter();

--- a/services/backend/src/db/migrations/20200731224921_add-tokens-to-user.js
+++ b/services/backend/src/db/migrations/20200731224921_add-tokens-to-user.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     await knex.schema.table('users', (table) => {
         // Add host id column
         table.string('host_id');
@@ -16,7 +16,7 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     await knex.schema.table('users', (table) => {
         // Remove host id column
         table.dropColumn('host_id');

--- a/services/backend/src/db/migrations/20200816130341_remove-host.js
+++ b/services/backend/src/db/migrations/20200816130341_remove-host.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     // Remove host columns & rename host_id to node_id
     await knex.schema.table('users', (table) => {
         table.renameColumn('host_id', 'node_id');
@@ -15,7 +15,7 @@ exports.up = async (knex) => {
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     // Add host columns & rename node_id to host_id
     await knex.schema.table('users', (table) => {
         table.renameColumn('node_id', 'host_id');

--- a/services/backend/src/db/migrations/20200906222353_change-installation-id-type.js
+++ b/services/backend/src/db/migrations/20200906222353_change-installation-id-type.js
@@ -1,11 +1,11 @@
-exports.up = async (knex) => {
+export const up = async (knex) => {
     // Change type from string to number on installation_id column
     await knex.schema.alterTable('repositories', (table) => {
         table.integer('installation_id').notNullable().alter();
     });
 };
 
-exports.down = async (knex) => {
+export const down = async (knex) => {
     // Change type from number to string on installation_id column
     await knex.schema.alterTable('repositories', (table) => {
         table.string('installation_id').nullable().alter();

--- a/services/backend/src/db/models/baseModel.js
+++ b/services/backend/src/db/models/baseModel.js
@@ -1,5 +1,7 @@
-const {compose, Model, QueryBuilder, UniqueViolationError} = require('objection');
-const guid = require('objection-guid');
+import objection from 'objection';
+import guid from 'objection-guid';
+
+const {compose, Model, QueryBuilder, UniqueViolationError} = objection;
 
 class BaseQueryBuilder extends QueryBuilder {
     async findOrInsert(params) {
@@ -24,7 +26,7 @@ const mixins = compose(
     guid(),
 );
 
-class BaseModel extends mixins(Model) {
+export default class BaseModel extends mixins(Model) {
     static get QueryBuilder() {
         return BaseQueryBuilder;
     }
@@ -41,5 +43,3 @@ class BaseModel extends mixins(Model) {
         this.updatedAt = new Date().toISOString();
     }
 }
-
-module.exports = BaseModel;

--- a/services/backend/src/db/models/baseModel.test.js
+++ b/services/backend/src/db/models/baseModel.test.js
@@ -1,5 +1,5 @@
-const {transactionPerTest} = require('objection-transactional-tests');
-const {knex, Repository} = require('db/');
+import {transactionPerTest} from 'objection-transactional-tests';
+import knex, {Repository} from '../index.js';
 
 beforeAll(() => {
     transactionPerTest();

--- a/services/backend/src/db/models/index.js
+++ b/services/backend/src/db/models/index.js
@@ -1,11 +1,88 @@
-const User = require('./user');
-const Repository = require('./repository');
-const Issue = require('./issue');
-const Task = require('./task');
+import BaseModel from './baseModel.js';
+import User from './user.js';
+import Repository from './repository.js';
+import Issue from './issue.js';
+import Task from './task.js';
 
-module.exports = {
+/* Since ECMAScript Modules can't do dynamic synchronous imports
+ * and Objection.js currently doesn't support making relationMappings asynchronous,
+ * the only solution to avoid require loops (circular dependencies)
+ * is to import each class here, and override the relationMappings static getter from this context.
+ * This means that models MUST be imported from this file, NOT their individual files in this folder. */
+
+User.relationMappings = () => {
+    return {
+        repositories: {
+            relation: BaseModel.ManyToManyRelation,
+            modelClass: Repository,
+            join: {
+                from: 'users.id',
+                to: 'repositories.id',
+                through: {
+                    from: 'userRepositories.userId',
+                    to: 'userRepositories.repositoryId',
+                },
+            }
+        }
+    };
+};
+
+Repository.relationMappings = () => {
+    return {
+        issues: {
+            relation: BaseModel.HasManyRelation,
+            modelClass: Issue,
+            join: {
+                from: 'repositories.id',
+                to: 'issues.repositoryId',
+            }
+        },
+        users: {
+            relation: BaseModel.ManyToManyRelation,
+            modelClass: User,
+            join: {
+                from: 'repositories.id',
+                to: 'users.id',
+                through: {
+                    from: 'user_repositories.repositoryId',
+                    to: 'user_repositories.userId',
+                },
+            }
+        }
+    };
+};
+
+Issue.relationMappings = () => {
+    return {
+        repository: {
+            relation: BaseModel.BelongsToOneRelation,
+            modelClass: Repository,
+            join: {
+                from: 'issues.repositoryId',
+                to: 'repositories.id',
+            }
+        }
+    };
+};
+
+Task.relationMappings = () => {
+    return {
+        repository: {
+            relation: BaseModel.BelongsToOneRelation,
+            modelClass: Repository,
+            join: {from: 'tasks.repositoryId', to: 'repositories.id'}
+        },
+        issue: {
+            relation: BaseModel.BelongsToOneRelation,
+            modelClass: Issue,
+            join: {from: 'tasks.issueId', to: 'issues.id'}
+        }
+    };
+};
+
+export {
     User,
     Repository,
     Issue,
-    Task,
+    Task
 };

--- a/services/backend/src/db/models/issue.js
+++ b/services/backend/src/db/models/issue.js
@@ -1,6 +1,6 @@
-const BaseModel = require('./baseModel');
+import BaseModel from './baseModel.js';
 
-class Issue extends BaseModel {
+export default class Issue extends BaseModel {
     static get tableName() {
         return 'issues';
     }
@@ -18,21 +18,4 @@ class Issue extends BaseModel {
             }
         };
     }
-
-    static get relationMappings() {
-        const Repository = require('./repository');
-
-        return {
-            repository: {
-                relation: BaseModel.BelongsToOneRelation,
-                modelClass: Repository,
-                join: {
-                    from: 'issues.repositoryId',
-                    to: 'repositories.id',
-                }
-            }
-        };
-    }
 }
-
-module.exports = Issue;

--- a/services/backend/src/db/models/issue.test.js
+++ b/services/backend/src/db/models/issue.test.js
@@ -1,5 +1,5 @@
-const {transactionPerTest} = require('objection-transactional-tests');
-const {knex, Issue, Repository} = require('db/');
+import {transactionPerTest} from 'objection-transactional-tests';
+import knex, {Issue, Repository} from '../index.js';
 
 beforeAll(() => {
     transactionPerTest();

--- a/services/backend/src/db/models/repository.js
+++ b/services/backend/src/db/models/repository.js
@@ -1,6 +1,6 @@
-const BaseModel = require('./baseModel');
+import BaseModel from './baseModel.js';
 
-class Repository extends BaseModel {
+export default class Repository extends BaseModel {
     static get tableName() {
         return 'repositories';
     }
@@ -19,34 +19,4 @@ class Repository extends BaseModel {
             }
         };
     }
-
-    static get relationMappings() {
-        const Issue = require('./issue');
-        const User = require('./user');
-
-        return {
-            issues: {
-                relation: BaseModel.HasManyRelation,
-                modelClass: Issue,
-                join: {
-                    from: 'repositories.id',
-                    to: 'issues.repositoryId',
-                }
-            },
-            users: {
-                relation: BaseModel.ManyToManyRelation,
-                modelClass: User,
-                join: {
-                    from: 'repositories.id',
-                    to: 'users.id',
-                    through: {
-                        from: 'user_repositories.repositoryId',
-                        to: 'user_repositories.userId',
-                    },
-                }
-            }
-        };
-    }
 }
-
-module.exports = Repository;

--- a/services/backend/src/db/models/repository.test.js
+++ b/services/backend/src/db/models/repository.test.js
@@ -1,5 +1,5 @@
-const {transactionPerTest} = require('objection-transactional-tests');
-const {knex, Repository} = require('db/');
+import {transactionPerTest} from 'objection-transactional-tests';
+import knex, {Repository} from '../index.js';
 
 beforeAll(() => {
     transactionPerTest();

--- a/services/backend/src/db/models/task.js
+++ b/services/backend/src/db/models/task.js
@@ -1,6 +1,6 @@
-const BaseModel = require('./baseModel');
+import BaseModel from './baseModel.js';
 
-class Task extends BaseModel {
+export default class Task extends BaseModel {
     static get tableName() {
         return 'tasks';
     }
@@ -18,24 +18,4 @@ class Task extends BaseModel {
             }
         };
     }
-
-    static get relationMappings() {
-        const Repository = require('./repository');
-        const Issue = require('./issue');
-
-        return {
-            repository: {
-                relation: BaseModel.BelongsToOneRelation,
-                modelClass: Repository,
-                join: {from: 'tasks.repositoryId', to: 'repositories.id'}
-            },
-            issue: {
-                relation: BaseModel.BelongsToOneRelation,
-                modelClass: Issue,
-                join: {from: 'tasks.issueId', to: 'issues.id'}
-            }
-        };
-    }
 }
-
-module.exports = Task;

--- a/services/backend/src/db/models/task.test.js
+++ b/services/backend/src/db/models/task.test.js
@@ -1,5 +1,5 @@
-const {transactionPerTest} = require('objection-transactional-tests');
-const {knex, Issue, Repository, Task} = require('db/');
+import {transactionPerTest} from 'objection-transactional-tests';
+import knex, {Issue, Repository, Task} from '../index.js';
 
 beforeAll(() => {
     transactionPerTest();

--- a/services/backend/src/db/models/user.js
+++ b/services/backend/src/db/models/user.js
@@ -1,13 +1,13 @@
-const {compose} = require('objection');
-const password = require('objection-password');
-const BaseModel = require('./baseModel');
-const {encrypt, decrypt} = require('../../utils/');
+import {compose} from 'objection';
+import password from 'objection-password';
+import BaseModel from './baseModel.js';
+import {encrypt, decrypt} from '../../utils/index.js';
 
 const mixins = compose(
     password({rounds: 13}),
 );
 
-class User extends mixins(BaseModel) {
+export default class User extends mixins(BaseModel) {
     static get tableName() {
         return 'users';
     }
@@ -28,25 +28,6 @@ class User extends mixins(BaseModel) {
                 refreshTokenIv: {type: ['string', null]},
                 createdAt: {type: 'string', format: 'date-time'},
                 updatedAt: {type: 'string', format: 'date-time'},
-            }
-        };
-    }
-
-    static get relationMappings() {
-        const Repository = require('./repository');
-
-        return {
-            repositories: {
-                relation: BaseModel.ManyToManyRelation,
-                modelClass: Repository,
-                join: {
-                    from: 'users.id',
-                    to: 'repositories.id',
-                    through: {
-                        from: 'userRepositories.userId',
-                        to: 'userRepositories.repositoryId',
-                    },
-                }
             }
         };
     }
@@ -79,5 +60,3 @@ class User extends mixins(BaseModel) {
         return {accessToken, refreshToken};
     }
 }
-
-module.exports = User;

--- a/services/backend/src/db/models/user.test.js
+++ b/services/backend/src/db/models/user.test.js
@@ -1,5 +1,5 @@
-const {transactionPerTest} = require('objection-transactional-tests');
-const {knex, User} = require('db/');
+import {transactionPerTest} from 'objection-transactional-tests';
+import knex, {User} from '../index.js';
 
 beforeAll(() => {
     transactionPerTest();

--- a/services/backend/src/db/seeds/seeds.js
+++ b/services/backend/src/db/seeds/seeds.js
@@ -1,7 +1,7 @@
-const {User, Repository, Issue, Task} = require('../models/');
-require('../'); // connect db
+import {User, Repository, Issue, Task} from '../models/index.js';
+import '../index.js'; // connect db
 
-const seed = async (knex) => {
+export const seed = async (knex) => {
     const environment = process.env.NODE_ENV || 'development';
     if (environment === 'production') {
         return;
@@ -133,7 +133,3 @@ const generateSeedData = async (knex) => {
     await user3.$relatedQuery('repositories').relate([repository3, repository4, repository5]);
 };
 /* eslint-enable */
-
-module.exports = {
-    seed
-};

--- a/services/backend/src/github/appAuthentication.js
+++ b/services/backend/src/github/appAuthentication.js
@@ -1,5 +1,5 @@
-const {createAppAuth} = require('@octokit/auth-app');
-const {logger} = require('utils/');
+import {createAppAuth} from '@octokit/auth-app';
+import {logger} from '../utils/index.js';
 
 const APP_ID = process.env.GITHUB_APP_ID;
 const PRIVATE_KEY = process.env.GITHUB_APP_PRIVATE_KEY.replace(/\\n/g, '\n');
@@ -14,4 +14,4 @@ const auth = createAppAuth({
     log: logger,
 });
 
-module.exports = auth;
+export default auth;

--- a/services/backend/src/github/scanGithubRepository.js
+++ b/services/backend/src/github/scanGithubRepository.js
@@ -1,7 +1,7 @@
-const tempy = require('tempy');
-const {logger} = require('utils/');
-const {createInstallationClient, downloadRepository} = require('github/utils/');
-const {scanCodebase} = require('parser/');
+import tempy from 'tempy';
+import {logger} from '../utils/index.js';
+import {createInstallationClient, downloadRepository} from './utils/index.js';
+import {scanCodebase} from '../parser/index.js';
 
 const scanGithubRepository = async (repository) => {
     const githubClient = await createInstallationClient(repository.installationId);
@@ -17,4 +17,4 @@ const scanGithubRepository = async (repository) => {
     });
 };
 
-module.exports = scanGithubRepository;
+export default scanGithubRepository;

--- a/services/backend/src/github/utils/createIssue.js
+++ b/services/backend/src/github/utils/createIssue.js
@@ -1,5 +1,5 @@
-const {URL} = require('url');
-const {logger, graphqlRequestBody, markdownHelpers} = require('utils/');
+import {URL} from 'url';
+import {logger, graphqlRequestBody, markdownHelpers} from '../../utils/index.js';
 
 const {inlineCode, codeBlock, lineBreak} = markdownHelpers;
 
@@ -46,4 +46,4 @@ const createIssue = async (githubClient, issue, repository, issueReferences) => 
     return response.data.data.createIssue.issue;
 };
 
-module.exports = createIssue;
+export default createIssue;

--- a/services/backend/src/github/utils/downloadRepository.js
+++ b/services/backend/src/github/utils/downloadRepository.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const globby = require('globby');
-const {asyncUnzip, asyncWriteFile, logger, graphqlRequestBody} = require('utils/');
+import fs from 'fs';
+import globby from 'globby';
+import {asyncUnzip, asyncWriteFile, logger, graphqlRequestBody} from '../../utils/index.js';
 
 const fsPromises = fs.promises;
 
@@ -59,4 +59,4 @@ const downloadRepository = async (githubClient, repositoryNodeId, destination) =
     return codeFolder;
 };
 
-module.exports = downloadRepository;
+export default downloadRepository;

--- a/services/backend/src/github/utils/getAvatarUrl.js
+++ b/services/backend/src/github/utils/getAvatarUrl.js
@@ -1,4 +1,4 @@
-const {logger, graphqlRequestBody} = require('utils/');
+import {logger, graphqlRequestBody} from '../../utils/index.js';
 
 // Get a url to the user's avatar
 const getAvatarUrl = async (githubClient, userNodeId) => {
@@ -18,4 +18,4 @@ const getAvatarUrl = async (githubClient, userNodeId) => {
     return response.data.data.node.avatarUrl;
 };
 
-module.exports = getAvatarUrl;
+export default getAvatarUrl;

--- a/services/backend/src/github/utils/getInstallationRepositories.js
+++ b/services/backend/src/github/utils/getInstallationRepositories.js
@@ -1,4 +1,4 @@
-const {logger} = require('utils/');
+import {logger} from '../../utils/index.js';
 
 /* Get list of repositories associated with an installation ID from GitHub.
  * Using this API under "list repositories accessible to the app installation":
@@ -33,4 +33,4 @@ const getInstallationRepositories = async (installationClient) => {
     return repositories;
 };
 
-module.exports = getInstallationRepositories;
+export default getInstallationRepositories;

--- a/services/backend/src/github/utils/getIssue.js
+++ b/services/backend/src/github/utils/getIssue.js
@@ -1,5 +1,5 @@
-const {URL} = require('url');
-const {logger, graphqlRequestBody} = require('utils/');
+import {URL} from 'url';
+import {logger, graphqlRequestBody} from '../../utils/index.js';
 
 const PATHNAME_REGEX = /\/(?<owner>.+)\/(?<name>.+)\/issues\/(?<issueNumber>\d+)/;
 
@@ -30,4 +30,4 @@ const getIssue = async (githubClient, issue) => {
     return response.data.data.repository.issue;
 };
 
-module.exports = getIssue;
+export default getIssue;

--- a/services/backend/src/github/utils/githubClients.js
+++ b/services/backend/src/github/utils/githubClients.js
@@ -1,7 +1,7 @@
-const axios = require('axios');
-const auth = require('github/appAuthentication');
+import axios from 'axios';
+import auth from '../appAuthentication.js';
 
-const createAppClient = async () => {
+export const createAppClient = async () => {
     const {token} = await auth({type: 'app'});
 
     return axios.create({
@@ -16,7 +16,7 @@ const createAppClient = async () => {
     });
 };
 
-const createInstallationClient = async (installationId) => {
+export const createInstallationClient = async (installationId) => {
     const {token} = await auth({type: 'installation', installationId});
 
     return axios.create({
@@ -31,7 +31,7 @@ const createInstallationClient = async (installationId) => {
     });
 };
 
-const createOauthClient = async (token) => {
+export const createOauthClient = async (token) => {
     return axios.create({
         baseURL: 'https://api.github.com',
         headers: {
@@ -42,10 +42,4 @@ const createOauthClient = async (token) => {
             }
         }
     });
-};
-
-module.exports = {
-    createAppClient,
-    createInstallationClient,
-    createOauthClient,
 };

--- a/services/backend/src/github/utils/index.js
+++ b/services/backend/src/github/utils/index.js
@@ -1,17 +1,6 @@
-const {createAppClient, createInstallationClient, createOauthClient} = require('./githubClients');
-const downloadRepository = require('./downloadRepository');
-const getIssue = require('./getIssue');
-const createIssue = require('./createIssue');
-const getInstallationRepositories = require('./getInstallationRepositories');
-const getAvatarUrl = require('./getAvatarUrl');
-
-module.exports = {
-    createAppClient,
-    createInstallationClient,
-    createOauthClient,
-    downloadRepository,
-    getIssue,
-    createIssue,
-    getInstallationRepositories,
-    getAvatarUrl,
-};
+export {createAppClient, createInstallationClient, createOauthClient} from './githubClients.js';
+export {default as downloadRepository} from './downloadRepository.js';
+export {default as getIssue} from './getIssue.js';
+export {default as createIssue} from './createIssue.js';
+export {default as getInstallationRepositories} from './getInstallationRepositories.js';
+export {default as getAvatarUrl} from './getAvatarUrl.js';

--- a/services/backend/src/github/webhooks/index.js
+++ b/services/backend/src/github/webhooks/index.js
@@ -1,12 +1,12 @@
-const logger = require('utils/logger');
-const {Webhooks} = require('@octokit/webhooks');
-const {
+import {logger} from '../../utils/index.js';
+import {Webhooks} from '@octokit/webhooks';
+import {
     onInstallationCreated,
     onInstallationDeleted,
     onInstallationRepositoriesAdded,
     onInstallationRepositoriesRemoved,
-} = require('./installation');
-const {onPush} = require('./push');
+} from './installation.js';
+import {onPush} from './push.js';
 
 const webhooks = new Webhooks({
     secret: process.env.GITHUB_WEBHOOKS_SECRET,
@@ -27,4 +27,4 @@ webhooks.on('installation_repositories.added', onInstallationRepositoriesAdded);
 webhooks.on('installation_repositories.removed', onInstallationRepositoriesRemoved);
 webhooks.on('push', onPush);
 
-module.exports = webhooks;
+export default webhooks;

--- a/services/backend/src/github/webhooks/installation.js
+++ b/services/backend/src/github/webhooks/installation.js
@@ -1,7 +1,7 @@
-const {Repository} = require('db/');
-const scanGithubRepository = require('github/scanGithubRepository');
+import {Repository} from '../../db/index.js';
+import scanGithubRepository from '../scanGithubRepository.js';
 
-const onInstallationCreated = async ({payload}) => {
+export const onInstallationCreated = async ({payload}) => {
     const installationId = payload.installation.id;
 
     await Promise.allSettled(payload.repositories.map(async ({node_id: nodeId}) => {
@@ -10,13 +10,13 @@ const onInstallationCreated = async ({payload}) => {
     }));
 };
 
-const onInstallationDeleted = async ({payload}) => {
+export const onInstallationDeleted = async ({payload}) => {
     for (const {node_id: nodeId} of payload.repositories) {
         await Repository.query().delete().where({nodeId});
     }
 };
 
-const onInstallationRepositoriesAdded = async ({payload}) => {
+export const onInstallationRepositoriesAdded = async ({payload}) => {
     const installationId = payload.installation.id;
 
     await Promise.allSettled(payload.repositories_added.map(async ({node_id: nodeId}) => {
@@ -25,15 +25,8 @@ const onInstallationRepositoriesAdded = async ({payload}) => {
     }));
 };
 
-const onInstallationRepositoriesRemoved = async ({payload}) => {
+export const onInstallationRepositoriesRemoved = async ({payload}) => {
     for (const {node_id: nodeId} of payload.repositories_removed) {
         await Repository.query().delete().where({nodeId});
     }
-};
-
-module.exports = {
-    onInstallationCreated,
-    onInstallationDeleted,
-    onInstallationRepositoriesAdded,
-    onInstallationRepositoriesRemoved,
 };

--- a/services/backend/src/github/webhooks/push.js
+++ b/services/backend/src/github/webhooks/push.js
@@ -1,8 +1,8 @@
-const {Repository} = require('db/');
-const {logger} = require('utils/');
-const scanGithubRepository = require('github/scanGithubRepository');
+import {Repository} from '../../db/index.js';
+import {logger} from '../../utils/index.js';
+import scanGithubRepository from '../scanGithubRepository.js';
 
-const onPush = async ({payload}) => {
+export const onPush = async ({payload}) => {
     const defaultBranch = payload.repository.default_branch;
     const branchMatch = payload.ref.match(/refs\/heads\/(?<branchName>.*)/);
 
@@ -22,5 +22,3 @@ const onPush = async ({payload}) => {
 
     await scanGithubRepository(repository);
 };
-
-module.exports = {onPush};

--- a/services/backend/src/graphql/apolloServer.js
+++ b/services/backend/src/graphql/apolloServer.js
@@ -1,7 +1,7 @@
-const {ApolloServer, gql} = require('apollo-server-express');
-const typeDefs = require('graphql/schema');
-const resolvers = require('graphql/resolvers');
-const db = require('db/');
+import {ApolloServer, gql} from 'apollo-server-express';
+import typeDefs from './schema/index.js';
+import resolvers from './resolvers/index.js';
+import knex, * as models from '../db/index.js';
 
 const playground = {
     settings: {'editor.cursorShape': 'line'}
@@ -9,7 +9,8 @@ const playground = {
 
 const context = ({req}) => {
     return {
-        ...db,
+        knex,
+        ...models,
         request: req,
     };
 };
@@ -21,4 +22,4 @@ const apolloServer = new ApolloServer({
     playground,
 });
 
-module.exports = apolloServer;
+export default apolloServer;

--- a/services/backend/src/graphql/resolvers/index.js
+++ b/services/backend/src/graphql/resolvers/index.js
@@ -1,9 +1,9 @@
-const {userQueries, userMutations} = require('./users');
-const {repositoryQueries, repositoryMutations} = require('./repositories');
-const {issueQueries, issueMutations} = require('./issues');
-const {taskQueries, taskMutations} = require('./tasks');
+import {userQueries, userMutations} from './users.js';
+import {repositoryQueries, repositoryMutations} from './repositories.js';
+import {issueQueries, issueMutations} from './issues.js';
+import {taskQueries, taskMutations} from './tasks.js';
 
-module.exports = {
+const resolvers = {
     User: {
         repositories: (parent, args, context, info) => parent.$relatedQuery('repositories')
     },
@@ -31,3 +31,5 @@ module.exports = {
         ...taskMutations,
     }
 };
+
+export default resolvers;

--- a/services/backend/src/graphql/resolvers/issues.js
+++ b/services/backend/src/graphql/resolvers/issues.js
@@ -1,14 +1,9 @@
-const issueQueries = {
+export const issueQueries = {
     issues: (parent, args, {Issue}, info) => Issue.query()
 };
 
-const issueMutations = {
+export const issueMutations = {
     createIssue: async (parent, {issueInput}, {Issue}, info) => {
         return await Issue.query().insert(issueInput);
     }
-};
-
-module.exports = {
-    issueQueries,
-    issueMutations,
 };

--- a/services/backend/src/graphql/resolvers/repositories.js
+++ b/services/backend/src/graphql/resolvers/repositories.js
@@ -1,14 +1,9 @@
-const repositoryQueries = {
+export const repositoryQueries = {
     repositories: (parent, args, {Repository}, info) => Repository.query()
 };
 
-const repositoryMutations = {
+export const repositoryMutations = {
     createRepository: async (parent, {repositoryInput}, {Repository}, info) => {
         return await Repository.query().findOrInsert(repositoryInput);
     }
-};
-
-module.exports = {
-    repositoryQueries,
-    repositoryMutations,
 };

--- a/services/backend/src/graphql/resolvers/tasks.js
+++ b/services/backend/src/graphql/resolvers/tasks.js
@@ -1,16 +1,11 @@
-const taskQueries = {
+export const taskQueries = {
     tasks: (parent, args, {Task}, info) => Task.query()
 };
 
-const taskMutations = {
+export const taskMutations = {
     createTask: async (parent, {taskInput}, {Task}, info) => {
         const {nodeId, repositoryId, issueId} = taskInput;
 
         return await Task.query().insert({nodeId, repositoryId, issueId});
     }
-};
-
-module.exports = {
-    taskQueries,
-    taskMutations,
 };

--- a/services/backend/src/graphql/resolvers/users.js
+++ b/services/backend/src/graphql/resolvers/users.js
@@ -1,17 +1,12 @@
-const userQueries = {
+export const userQueries = {
     users: (parent, args, {User}, info) => User.query()
 };
 
-const userMutations = {
+export const userMutations = {
     createUser: async (parent, {userInput}, {User}, info) => {
         return await User.query().insert({
             email: userInput.email,
             password: userInput.password
         });
     }
-};
-
-module.exports = {
-    userQueries,
-    userMutations,
 };

--- a/services/backend/src/graphql/schema/index.js
+++ b/services/backend/src/graphql/schema/index.js
@@ -1,4 +1,4 @@
-module.exports = `
+const schema = `
     type User {
         id: ID!
         email: String!
@@ -66,3 +66,5 @@ module.exports = `
         mutation: RootMutation
     }
 `;
+
+export default schema;

--- a/services/backend/src/index.js
+++ b/services/backend/src/index.js
@@ -1,5 +1,5 @@
-const logger = require('utils/logger');
-const app = require('./app');
+import logger from './utils/logger.js';
+import app from './app.js';
 
 const host = app.get('host');
 const port = app.get('port');

--- a/services/backend/src/jobs/addGithubInstallationIds.js
+++ b/services/backend/src/jobs/addGithubInstallationIds.js
@@ -1,6 +1,6 @@
-const {Repository} = require('db/');
-const {logger} = require('utils/');
-const {createAppClient, createInstallationClient} = require('github/utils');
+import {Repository} from '../db/index.js';
+import {logger} from '../utils/index.js';
+import {createAppClient, createInstallationClient} from '../github/utils/index.js';
 
 /*
  * This job queries the GitHub API and adds missing installation ids to repositories in the database.

--- a/services/backend/src/jobs/addMissingGithubRepositories.js
+++ b/services/backend/src/jobs/addMissingGithubRepositories.js
@@ -1,6 +1,6 @@
-const {Repository} = require('db/');
-const {logger} = require('utils/');
-const {createAppClient, createInstallationClient, getInstallationRepositories} = require('github/utils');
+import {Repository} from '../db/index.js';
+import {logger} from '../utils/index.js';
+import {createAppClient, createInstallationClient, getInstallationRepositories} from '../github/utils/index.js';
 
 /*
  * This job queries the GitHub API and deletes repositories where BlockedTODO isn't installed from the database.

--- a/services/backend/src/jobs/backupDatabase.js
+++ b/services/backend/src/jobs/backupDatabase.js
@@ -1,9 +1,9 @@
-const util = require('util');
-const childProcess = require('child_process');
-const {promises: fsPromises} = require('fs');
-const {Storage} = require('@google-cloud/storage');
-const knexConfig = require('../db/config/knexfile');
-const {logger} = require('utils/');
+import util from 'util';
+import childProcess from 'child_process';
+import {promises as fsPromises} from 'fs';
+import {Storage} from '@google-cloud/storage';
+import knexConfig from '../db/config/knexfile';
+import {logger} from '../utils/index.js';
 
 const environment = process.env.NODE_ENV || 'development';
 const exec = util.promisify(childProcess.exec);

--- a/services/backend/src/jobs/pruneGithubRepositories.js
+++ b/services/backend/src/jobs/pruneGithubRepositories.js
@@ -1,6 +1,6 @@
-const {Repository} = require('db/');
-const {logger} = require('utils/');
-const {createAppClient, createInstallationClient, getInstallationRepositories} = require('github/utils');
+import {Repository} from '../db/index.js';
+import {logger} from '../utils/index.js';
+import {createAppClient, createInstallationClient, getInstallationRepositories} from '../github/utils/index.js';
 
 /*
  * This job queries the GitHub API and deletes repositories where BlockedTODO isn't installed from the database.

--- a/services/backend/src/jobs/scanRepositories.js
+++ b/services/backend/src/jobs/scanRepositories.js
@@ -1,6 +1,6 @@
-const {Repository} = require('db/');
-const {logger} = require('utils/');
-const scanGithubRepository = require('github/scanGithubRepository');
+import {Repository} from '../db/index.js';
+import {logger} from '../utils/index.js';
+import scanGithubRepository from '../github/scanGithubRepository.js';
 
 const scanRepositories = async () => {
     const repositories = await Repository.query();

--- a/services/backend/src/middleware/errorHandler.js
+++ b/services/backend/src/middleware/errorHandler.js
@@ -1,5 +1,5 @@
-const logger = require('utils/logger');
-const {AuthenticationError} = require('utils/errors');
+import logger from '../utils/logger.js';
+import {AuthenticationError} from '../utils/errors.js';
 
 const errorHandler = (err, req, res, next) => {
     logger.error(err.stack);
@@ -10,4 +10,4 @@ const errorHandler = (err, req, res, next) => {
     }
 };
 
-module.exports = errorHandler;
+export default errorHandler;

--- a/services/backend/src/middleware/index.js
+++ b/services/backend/src/middleware/index.js
@@ -1,11 +1,4 @@
-const errorHandler = require('./errorHandler');
-const requireAuth = require('./requireAuth');
-const passport = require('./passport');
-const sessions = require('./sessions');
-
-module.exports = {
-    errorHandler,
-    requireAuth,
-    passport,
-    sessions,
-};
+export {default as errorHandler} from './errorHandler.js';
+export {default as requireAuth} from './requireAuth.js';
+export {default as passport} from './passport.js';
+export {default as sessions} from './sessions.js';

--- a/services/backend/src/middleware/passport.js
+++ b/services/backend/src/middleware/passport.js
@@ -1,9 +1,9 @@
-const passport = require('passport');
-const {Strategy: LocalStrategy} = require('passport-local');
-const {Strategy: GithubStrategy} = require('passport-github');
-const cryptoRandomString = require('crypto-random-string');
-const {AuthenticationError} = require('utils/errors');
-const {User} = require('db/');
+import passport from 'passport';
+import {Strategy as LocalStrategy} from 'passport-local';
+import {Strategy as GithubStrategy} from 'passport-github';
+import cryptoRandomString from 'crypto-random-string';
+import {AuthenticationError} from '../utils/errors.js';
+import {User} from '../db/index.js';
 
 passport.serializeUser((user, done) => {
     done(null, user.id);
@@ -75,4 +75,4 @@ const githubVerify = async (accessToken, refreshToken, profile, done) => {
 const githubStrategy = new GithubStrategy(githubConfig, githubVerify);
 passport.use(githubStrategy);
 
-module.exports = passport;
+export default passport;

--- a/services/backend/src/middleware/requireAuth.js
+++ b/services/backend/src/middleware/requireAuth.js
@@ -6,4 +6,4 @@ const requireAuth = async (req, res, next) => {
     }
 };
 
-module.exports = requireAuth;
+export default requireAuth;

--- a/services/backend/src/middleware/sessions.js
+++ b/services/backend/src/middleware/sessions.js
@@ -1,6 +1,6 @@
-const session = require('express-session');
-const connectSessionKnex = require('connect-session-knex');
-const {knex} = require('db/');
+import session from 'express-session';
+import connectSessionKnex from 'connect-session-knex';
+import knex from '../db/index.js';
 
 const environment = process.env.NODE_ENV || 'development';
 
@@ -23,4 +23,4 @@ const sessions = () => {
     });
 };
 
-module.exports = sessions;
+export default sessions;

--- a/services/backend/src/parser/getConfig.js
+++ b/services/backend/src/parser/getConfig.js
@@ -1,7 +1,7 @@
-const yaml = require('js-yaml');
-const {promises: fsPromises} = require('fs');
-const {logger, DEFAULT_CONFIG} = require('utils/');
-const {CONFIG_FILE_NAME_REGEX} = require('./regex');
+import yaml from 'js-yaml';
+import {promises as fsPromises} from 'fs';
+import {logger, DEFAULT_CONFIG} from '../utils/index.js';
+import {CONFIG_FILE_NAME_REGEX} from './regex/index.js';
 
 const getConfig = async (codeFolder) => {
     const rootFiles = await fsPromises.readdir(codeFolder);
@@ -36,4 +36,4 @@ const loadConfig = async (filePath) => {
     }
 };
 
-module.exports = getConfig;
+export default getConfig;

--- a/services/backend/src/parser/getConfig.test.js
+++ b/services/backend/src/parser/getConfig.test.js
@@ -1,7 +1,7 @@
-const getConfig = require('./getConfig');
-const tempy = require('tempy');
-const {DEFAULT_CONFIG} = require('utils/');
-const {promises: fsPromises} = require('fs');
+import getConfig from './getConfig.js';
+import tempy from 'tempy';
+import {DEFAULT_CONFIG} from '../utils/index.js';
+import {promises as fsPromises} from 'fs';
 
 const configText = `
     comment_prefixes:

--- a/services/backend/src/parser/index.js
+++ b/services/backend/src/parser/index.js
@@ -1,12 +1,4 @@
-const parseCodebase = require('./parseCodebase');
-const {createMissingIssues, deleteUnreferencedIssues} = require('./issueHandler');
-const {createMissingTasks} = require('./taskHandler');
-const scanCodebase = require('./scanCodebase');
-
-module.exports = {
-    parseCodebase,
-    createMissingIssues,
-    deleteUnreferencedIssues,
-    createMissingTasks,
-    scanCodebase,
-};
+export {default as parseCodebase} from './parseCodebase.js';
+export {createMissingIssues, deleteUnreferencedIssues} from './issueHandler.js';
+export {createMissingTasks} from './taskHandler.js';
+export {default as scanCodebase} from './scanCodebase.js';

--- a/services/backend/src/parser/issueHandler.js
+++ b/services/backend/src/parser/issueHandler.js
@@ -1,7 +1,7 @@
-const {Issue} = require('db/');
+import {Issue} from '../db/index.js';
 
 /* Delete issues that are no longer mentioned in the codebase from the repository */
-const deleteUnreferencedIssues = async (repository, referencedIssues) => {
+export const deleteUnreferencedIssues = async (repository, referencedIssues) => {
     const issues = await repository.$relatedQuery('issues');
     for (const issue of issues) {
         if (issue.url in referencedIssues) {
@@ -14,7 +14,7 @@ const deleteUnreferencedIssues = async (repository, referencedIssues) => {
 
 /* Add missing issues to the database.
  * Takes a list of issue urls and creates them if they don't exist. */
-const createMissingIssues = async (repository, referencedIssueUrls) => {
+export const createMissingIssues = async (repository, referencedIssueUrls) => {
     const handleIssue = async (issueUrl) => {
         const issue = await Issue.query().findOrInsert({url: issueUrl, repositoryId: repository.id});
 
@@ -22,9 +22,4 @@ const createMissingIssues = async (repository, referencedIssueUrls) => {
     };
 
     return await Promise.allSettled(referencedIssueUrls.map(handleIssue));
-};
-
-module.exports = {
-    deleteUnreferencedIssues,
-    createMissingIssues,
 };

--- a/services/backend/src/parser/parseCodebase.js
+++ b/services/backend/src/parser/parseCodebase.js
@@ -1,8 +1,8 @@
-const {promises: fsPromises} = require('fs');
-const globby = require('globby');
-const {logger} = require('utils/');
-const {COMMENT_REGEX, issueRegex} = require('./regex');
-const getConfig = require('./getConfig');
+import {promises as fsPromises} from 'fs';
+import globby from 'globby';
+import {logger} from '../utils/index.js';
+import {COMMENT_REGEX, issueRegex} from './regex/index.js';
+import getConfig from './getConfig.js';
 
 /* Return array of issue urls that match the issue regex in a single comment */
 const scanComment = (comment, config) => {
@@ -80,4 +80,4 @@ const parseCodebase = async (codeFolder) => {
     return mergeScanResults(results, codeFolder);
 };
 
-module.exports = parseCodebase;
+export default parseCodebase;

--- a/services/backend/src/parser/regex/commentRegex.js
+++ b/services/backend/src/parser/regex/commentRegex.js
@@ -39,4 +39,4 @@ const COMMENT_REGEX = new RegExp(
     GLOBAL_PATTERN_FLAGS
 );
 
-module.exports = COMMENT_REGEX;
+export default COMMENT_REGEX;

--- a/services/backend/src/parser/regex/commentRegex.test.js
+++ b/services/backend/src/parser/regex/commentRegex.test.js
@@ -1,4 +1,4 @@
-const COMMENT_REGEX = require('./commentRegex');
+import COMMENT_REGEX from './commentRegex.js';
 
 describe('JavaScript single-line comments', () => {
     it('matches a basic comment (sanity test)', () => {

--- a/services/backend/src/parser/regex/configFileNameRegex.js
+++ b/services/backend/src/parser/regex/configFileNameRegex.js
@@ -24,4 +24,4 @@ const CONFIG_FILE_NAME_REGEX = new RegExp(
     GLOBAL_PATTERN_FLAGS
 );
 
-module.exports = CONFIG_FILE_NAME_REGEX;
+export default CONFIG_FILE_NAME_REGEX;

--- a/services/backend/src/parser/regex/configFileNameRegex.test.js
+++ b/services/backend/src/parser/regex/configFileNameRegex.test.js
@@ -1,4 +1,4 @@
-const CONFIG_FILE_NAME_REGEX = require('./configFileNameRegex');
+import CONFIG_FILE_NAME_REGEX from './configFileNameRegex.js';
 
 describe('Config file name regex', () => {
     it('matches a valid file name (sanity test)', () => {

--- a/services/backend/src/parser/regex/index.js
+++ b/services/backend/src/parser/regex/index.js
@@ -1,9 +1,3 @@
-const issueRegex = require('./issueRegex');
-const COMMENT_REGEX = require('./commentRegex');
-const CONFIG_FILE_NAME_REGEX = require('./configFileNameRegex');
-
-module.exports = {
-    issueRegex,
-    COMMENT_REGEX,
-    CONFIG_FILE_NAME_REGEX,
-};
+export {default as issueRegex} from './issueRegex.js';
+export {default as COMMENT_REGEX} from './commentRegex.js';
+export {default as CONFIG_FILE_NAME_REGEX} from './configFileNameRegex.js';

--- a/services/backend/src/parser/regex/issueRegex.js
+++ b/services/backend/src/parser/regex/issueRegex.js
@@ -1,5 +1,5 @@
-const urlRegex = require('url-regex-safe');
-const {escapeRegex} = require('utils/');
+import urlRegex from 'url-regex-safe';
+import {escapeRegex} from '../../utils/index.js';
 
 /* URL regex. */
 const URL_REGEX = new RegExp('(?<url>' + urlRegex({strict: false}).source + ')').source;
@@ -29,4 +29,4 @@ const issueRegex = (config) => {
     return ISSUE_REGEX;
 };
 
-module.exports = issueRegex;
+export default issueRegex;

--- a/services/backend/src/parser/regex/issueRegex.test.js
+++ b/services/backend/src/parser/regex/issueRegex.test.js
@@ -1,5 +1,5 @@
-const issueRegex = require('./issueRegex');
-const {DEFAULT_CONFIG} = require('utils/');
+import issueRegex from './issueRegex.js';
+import {DEFAULT_CONFIG} from '../../utils/index.js';
 
 describe('Prefix regex', () => {
     it('matches a basic comment (sanity test)', () => {

--- a/services/backend/src/parser/scanCodebase.js
+++ b/services/backend/src/parser/scanCodebase.js
@@ -1,8 +1,8 @@
-const stringifyObject = require('stringify-object');
-const {logger} = require('utils/');
-const parseCodebase = require('./parseCodebase');
-const {deleteUnreferencedIssues, createMissingIssues} = require('./issueHandler');
-const {createMissingTasks} = require('./taskHandler');
+import stringifyObject from 'stringify-object';
+import {logger} from '../utils/index.js';
+import parseCodebase from './parseCodebase.js';
+import {deleteUnreferencedIssues, createMissingIssues} from './issueHandler.js';
+import {createMissingTasks} from './taskHandler.js';
 
 /* Perform a complete scan of a codebase. */
 const scanCodebase = async (codeFolder, repository, githubClient) => {
@@ -34,4 +34,4 @@ const scanCodebase = async (codeFolder, repository, githubClient) => {
     logger.info(`Missing tasks created for repo ${repository.id}`);
 };
 
-module.exports = scanCodebase;
+export default scanCodebase;

--- a/services/backend/src/parser/taskHandler.js
+++ b/services/backend/src/parser/taskHandler.js
@@ -1,10 +1,10 @@
-const {Task} = require('db/');
-const {URL} = require('url');
-const {logger} = require('utils/');
-const {getIssue, createIssue} = require('github/utils/');
+import {Task} from '../db/index.js';
+import {URL} from 'url';
+import {logger} from '../utils/index.js';
+import {getIssue, createIssue} from '../github/utils/index.js';
 
 // Create tasks
-const createMissingTasks = async (repository, githubClient, referencedIssues) => {
+export const createMissingTasks = async (repository, githubClient, referencedIssues) => {
     const issues = await repository.$relatedQuery('issues');
 
     const handleIssue = async (issue) => {
@@ -44,5 +44,3 @@ const createMissingTasks = async (repository, githubClient, referencedIssues) =>
 
     await Promise.allSettled(issues.map((issue) => handleIssue(issue)));
 };
-
-module.exports = {createMissingTasks};

--- a/services/backend/src/routes/auth.js
+++ b/services/backend/src/routes/auth.js
@@ -1,5 +1,5 @@
-const express = require('express');
-const {requireAuth, passport} = require('middleware/');
+import express from 'express';
+import {requireAuth, passport} from '../middleware/index.js';
 
 const authRouter = express.Router();
 
@@ -22,4 +22,4 @@ authRouter.get('/github/callback', passport.authenticate('github'), (req, res) =
     res.redirect(req.headers.referer);
 });
 
-module.exports = authRouter;
+export default authRouter;

--- a/services/backend/src/routes/github.js
+++ b/services/backend/src/routes/github.js
@@ -1,6 +1,6 @@
-const express = require('express');
-const {requireAuth} = require('middleware/');
-const {createOauthClient, getAvatarUrl} = require('github/utils');
+import express from 'express';
+import {requireAuth} from '../middleware/index.js';
+import {createOauthClient, getAvatarUrl} from '../github/utils/index.js';
 
 const githubRouter = express.Router();
 
@@ -13,4 +13,4 @@ githubRouter.get('/avatar', requireAuth, async (req, res) => {
     res.status(200).json({avatarUrl});
 });
 
-module.exports = githubRouter;
+export default githubRouter;

--- a/services/backend/src/routes/index.js
+++ b/services/backend/src/routes/index.js
@@ -1,7 +1,2 @@
-const authRouter = require('./auth');
-const githubRouter = require('./github');
-
-module.exports = {
-    authRouter,
-    githubRouter,
-};
+export {default as authRouter} from './auth.js';
+export {default as githubRouter} from './github.js';

--- a/services/backend/src/utils/asyncUnzip.js
+++ b/services/backend/src/utils/asyncUnzip.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const unzipper = require('unzipper');
-const logger = require('./logger');
+import fs from 'fs';
+import unzipper from 'unzipper';
+import logger from './logger.js';
 
 /* Promisify stream unzip function so we can use it with async/await */
 const asyncUnzip = (zipFile, outputPath) => {
@@ -15,4 +15,4 @@ const asyncUnzip = (zipFile, outputPath) => {
     });
 };
 
-module.exports = asyncUnzip;
+export default asyncUnzip;

--- a/services/backend/src/utils/asyncWriteFile.js
+++ b/services/backend/src/utils/asyncWriteFile.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const logger = require('./logger');
+import fs from 'fs';
+import logger from './logger.js';
 
 /* Promisify writing a file from a stream function so we can use it with async/await
  * As per https://github.com/nodejs/node/issues/28545, the fs promises API does not support this functionality. */
@@ -14,4 +14,4 @@ const asyncWriteFile = (data, outputPath) => {
     });
 };
 
-module.exports = asyncWriteFile;
+export default asyncWriteFile;

--- a/services/backend/src/utils/cryptography.js
+++ b/services/backend/src/utils/cryptography.js
@@ -1,5 +1,7 @@
-const {createCipheriv, createDecipheriv, createHash} = require('crypto');
-const cryptoRandomString = require('crypto-random-string');
+import crypto from 'crypto';
+import cryptoRandomString from 'crypto-random-string';
+
+const {createCipheriv, createDecipheriv, createHash} = crypto;
 
 /* Encryption method */
 const BLOCK_CIPHER = 'aes-256-cbc';
@@ -16,7 +18,7 @@ const generateKey = (secret) => {
     return createHash('sha256').update(String(secret)).digest('base64').substr(0, KEY_BYTE_LENGTH);
 };
 
-const encrypt = (text) => {
+export const encrypt = (text) => {
     const iv = cryptoRandomString({length: IV_BYTE_LENGTH});
     const key = generateKey(process.env.ENCRYPTION_SECRET);
 
@@ -27,7 +29,7 @@ const encrypt = (text) => {
     return [encrypted, iv];
 };
 
-const decrypt = (text, iv) => {
+export const decrypt = (text, iv) => {
     const key = generateKey(process.env.ENCRYPTION_SECRET);
 
     const decipher = createDecipheriv('aes-256-cbc', key, iv);
@@ -35,9 +37,4 @@ const decrypt = (text, iv) => {
     deciphered += decipher.final('utf8');
 
     return deciphered;
-};
-
-module.exports = {
-    encrypt,
-    decrypt,
 };

--- a/services/backend/src/utils/cryptography.test.js
+++ b/services/backend/src/utils/cryptography.test.js
@@ -1,4 +1,4 @@
-const {encrypt, decrypt} = require('./cryptography');
+import {encrypt, decrypt} from './cryptography.js';
 
 describe('encrypt', () => {
     it('encrypts a string', () => {

--- a/services/backend/src/utils/defaultConfig.js
+++ b/services/backend/src/utils/defaultConfig.js
@@ -2,4 +2,4 @@ const DEFAULT_CONFIG = {
     comment_prefixes: ['BlockedTODO:', 'NOTIFY:', 'Blocked by', 'Waiting on'], // Comment prefixes are case insensitive
 };
 
-module.exports = DEFAULT_CONFIG;
+export default DEFAULT_CONFIG;

--- a/services/backend/src/utils/errors.js
+++ b/services/backend/src/utils/errors.js
@@ -1,5 +1,1 @@
-class AuthenticationError extends Error {}
-
-module.exports = {
-    AuthenticationError,
-};
+export class AuthenticationError extends Error {}

--- a/services/backend/src/utils/escapeRegex.js
+++ b/services/backend/src/utils/escapeRegex.js
@@ -4,4 +4,4 @@ const escapeRegex = (string) => {
     return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 };
 
-module.exports = escapeRegex;
+export default escapeRegex;

--- a/services/backend/src/utils/graphqlRequestBody.js
+++ b/services/backend/src/utils/graphqlRequestBody.js
@@ -4,4 +4,4 @@ const graphqlRequestBody = (operation) => {
     return {query: operation};
 };
 
-module.exports = graphqlRequestBody;
+export default graphqlRequestBody;

--- a/services/backend/src/utils/index.js
+++ b/services/backend/src/utils/index.js
@@ -1,22 +1,10 @@
-const logger = require('./logger');
-const graphqlRequestBody = require('./graphqlRequestBody');
-const asyncUnzip = require('./asyncUnzip');
-const asyncWriteFile = require('./asyncWriteFile');
-const DEFAULT_CONFIG = require('./defaultConfig');
-const escapeRegex = require('./escapeRegex');
-const markdownHelpers = require('./markdownHelpers');
-const errors = require('./errors');
-const {encrypt, decrypt} = require('./cryptography');
-
-module.exports = {
-    logger,
-    graphqlRequestBody,
-    asyncUnzip,
-    asyncWriteFile,
-    DEFAULT_CONFIG,
-    escapeRegex,
-    markdownHelpers,
-    errors,
-    encrypt,
-    decrypt,
-};
+export {default as logger} from './logger.js';
+export {default as graphqlRequestBody} from './graphqlRequestBody.js';
+export {default as asyncUnzip} from './asyncUnzip.js';
+export {default as asyncWriteFile} from './asyncWriteFile.js';
+export {default as DEFAULT_CONFIG} from './defaultConfig.js';
+export {default as escapeRegex} from './escapeRegex.js';
+export * as markdownHelpers from './markdownHelpers.js';
+export * as errors from './errors.js';
+export {encrypt, decrypt} from './cryptography.js';
+export {filepath, dirpath, filename, dirname, resolvePath} from './pathHelpers.js';

--- a/services/backend/src/utils/logger.js
+++ b/services/backend/src/utils/logger.js
@@ -1,5 +1,7 @@
-const {createLogger, format, transports} = require('winston');
-const stringifyObject = require('stringify-object');
+import winston from 'winston';
+import stringifyObject from 'stringify-object';
+
+const {createLogger, format, transports} = winston;
 
 const environment = process.env.NODE_ENV || 'development';
 const logLevel = environment === 'test' ? 'warn' : 'info';
@@ -29,4 +31,4 @@ const logger = createLogger({
     ],
 });
 
-module.exports = logger;
+export default logger;

--- a/services/backend/src/utils/markdownHelpers.js
+++ b/services/backend/src/utils/markdownHelpers.js
@@ -1,17 +1,11 @@
-const inlineCode = (text) => {
+export const inlineCode = (text) => {
     return '`' + text + '`';
 };
 
-const codeBlock = (text) => {
+export const codeBlock = (text) => {
     return '```\n' + text + '\n```';
 };
 
-const lineBreak = () => {
+export const lineBreak = () => {
     return '\n\n<br />\n\n';
-};
-
-module.exports = {
-    inlineCode,
-    codeBlock,
-    lineBreak,
 };

--- a/services/backend/src/utils/pathHelpers.js
+++ b/services/backend/src/utils/pathHelpers.js
@@ -1,0 +1,20 @@
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+export const filepath = (importMeta) => {
+    return importMeta.url ? fileURLToPath(importMeta.url) : '';
+};
+
+export const dirpath = (importMeta) => {
+    return path.dirname(filepath(importMeta));
+};
+
+export const filename = (importMeta) => {
+    return path.basename(filepath(importMeta));
+};
+
+export const dirname = (importMeta) => {
+    return path.basename(dirpath(importMeta));
+};
+
+export const resolvePath = path.resolve;

--- a/services/backend/src/utils/pathHelpers.test.js
+++ b/services/backend/src/utils/pathHelpers.test.js
@@ -1,0 +1,32 @@
+import {filepath, dirpath, filename, dirname, resolvePath} from './pathHelpers.js';
+
+describe('filepath', () => {
+    it('returns the path from the project root to the current file', () => {
+        expect(filepath(import.meta)).toEqual('/backend/src/utils/pathHelpers.test.js');
+    });
+});
+
+describe('dirpath', () => {
+    it('returns the path from the project root to the current file\'s parent directory', () => {
+        expect(dirpath(import.meta)).toEqual('/backend/src/utils');
+    });
+});
+
+describe('filename', () => {
+    it('returns the name of the current file', () => {
+        expect(filename(import.meta)).toEqual('pathHelpers.test.js');
+    });
+});
+
+describe('dirname', () => {
+    it('returns the name of the current file\'s parent directory', () => {
+        expect(dirname(import.meta)).toEqual('utils');
+    });
+});
+
+describe('resolvePath', () => {
+    it('resolves a path from its components', () => {
+        const resolvedPath = resolvePath(dirpath(import.meta), filename(import.meta));
+        expect(resolvedPath).toEqual('/backend/src/utils/pathHelpers.test.js');
+    });
+});

--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -4,7 +4,6 @@ Frontend service to interact with the BlockedTODO backend.
 # Required environment variables
 All of these are automatically set when running with docker-compose, but do need to be set manually on production environments
 
-* `NODE_PATH=src`
 * `REACT_APP_BACKEND_PROTOCOL`
 * `REACT_APP_BACKEND_HOST`
 * `REACT_APP_BACKEND_PORT`

--- a/services/website/README.md
+++ b/services/website/README.md
@@ -7,7 +7,6 @@ This is the public website (blockedtodo.com). Once you authenticate, you land on
 # Required environment variables
 All of these are automatically set when running with docker-compose, but do need to be set manually on production environments
 
-* `NODE_PATH=src`
 * `REACT_APP_FRONTEND_PROTOCOL`
 * `REACT_APP_FRONTEND_HOST`
 * `REACT_APP_FRONTEND_PORT`


### PR DESCRIPTION
Changelog:
- Removed reliance on NODE_PATH=src/
- Use relative paths instead of absolute paths
- Import index.js instead of the parent folder name
- Use import/export/default syntax instead of module.import/module.export
- For Objection.js models, move the relationMappings implementation to the index.js file inside the models/ folder. This allows us to avoid circular dependencies while still using ECMAScript asynchronous imports.
- Run tests with NODE_OPTIONS=--EXPERIMENTAL-VM-MODULES
- Increased Jest test timeout from 5 seconds to 8 seconds (unrelated, but bundled it with this change)
- Add pathHelpers utils (unrelated, but bundled it with this change)