### PR TITLE
Create webhooks express middleware.

### DIFF
--- a/services/backend/src/app.js
+++ b/services/backend/src/app.js
@@ -3,8 +3,7 @@ import cors from 'cors';
 import morgan from 'morgan';
 import cookieParser from 'cookie-parser';
 import apolloServer from './graphql/apolloServer.js';
-import {errorHandler, passport, sessions} from './middleware/index.js';
-import githubWebhooks from './github/webhooks/index.js';
+import {errorHandler, passport, sessions, githubWebhooks} from './middleware/index.js';
 import {authRouter, githubRouter} from './routes/index.js';
 
 const app = express();
@@ -22,7 +21,7 @@ app.use(sessions());
 app.use(passport.initialize());
 app.use(passport.session());
 
-app.use(githubWebhooks.middleware);
+app.use(githubWebhooks);
 
 app.get('/', (req, res, next) => {
     res.send('BlockedTODO Backend Server');

--- a/services/backend/src/github/webhooks/index.js
+++ b/services/backend/src/github/webhooks/index.js
@@ -9,8 +9,7 @@ import {
 import {onPush} from './push.js';
 
 const webhooks = new Webhooks({
-    secret: process.env.GITHUB_WEBHOOKS_SECRET,
-    path: '/github_event_handler',
+    secret: process.env.GITHUB_WEBHOOKS_SECRET
 });
 
 webhooks.onAny(({id, name, payload}) => {

--- a/services/backend/src/middleware/githubWebhooks.js
+++ b/services/backend/src/middleware/githubWebhooks.js
@@ -1,0 +1,12 @@
+import {createNodeMiddleware} from '@octokit/webhooks';
+import webhooks from '../github/webhooks/index.js';
+import {logger} from '../utils/index.js';
+
+const options = {
+    path: '/github_event_handler',
+    log: logger,
+};
+
+const githubWebhooks = createNodeMiddleware(webhooks, options);
+
+export default githubWebhooks;

--- a/services/backend/src/middleware/index.js
+++ b/services/backend/src/middleware/index.js
@@ -1,4 +1,5 @@
 export {default as errorHandler} from './errorHandler.js';
+export {default as githubWebhooks} from './githubWebhooks.js';
 export {default as requireAuth} from './requireAuth.js';
 export {default as passport} from './passport.js';
 export {default as sessions} from './sessions.js';


### PR DESCRIPTION
Old method was deprecated. Using createNodeMiddleware as per the @octokit/webhooks docs.