### PR TITLE
Update ingress from v1beta1 to v1 (for ingress v1.22).

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,53 +1,77 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-    name: blockedtodo-ingress
-    annotations:
-        kubernetes.io/ingress.class: gce
-        kubernetes.io/ingress.global-static-ip-name: {{.Values.static_ip_name}}
-        networking.gke.io/managed-certificates: blockedtodo-certificate
-        networking.gke.io/v1beta1.FrontendConfig: https-redirect
-    namespace: {{.Values.namespace}}
+  name: blockedtodo-ingress
+  annotations:
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/ingress.global-static-ip-name: {{.Values.static_ip_name}}
+    networking.gke.io/managed-certificates: blockedtodo-certificate
+    networking.gke.io/v1beta1.FrontendConfig: https-redirect
+  namespace: {{.Values.namespace}}
 spec:
-    rules:
-      - host: {{.Values.backend.host}}
-        http:
-            paths:
-              - backend:
-                    serviceName: backend-service
-                    servicePort: {{.Values.backend.port}}
-      - host: www.{{.Values.backend.host}}
-        http:
-            paths:
-              - backend:
-                    serviceName: backend-service
-                    servicePort: {{.Values.backend.port}}
+  rules:
+    - host: {{.Values.backend.host}}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend-service
+                port:
+                  number: {{.Values.backend.port}}
+    - host: www.{{.Values.backend.host}}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend-service
+                port:
+                  number: {{.Values.backend.port}}
 
-      - host: {{.Values.frontend.host}}
-        http:
-            paths:
-              - backend:
-                    serviceName: frontend-service
-                    servicePort: {{.Values.frontend.port}}
-      - host: www.{{.Values.frontend.host}}
-        http:
-            paths:
-              - backend:
-                    serviceName: frontend-service
-                    servicePort: {{.Values.frontend.port}}
+    - host: {{.Values.frontend.host}}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-service
+                port:
+                  number: {{.Values.frontend.port}}
+    - host: www.{{.Values.frontend.host}}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-service
+                port:
+                  number: {{.Values.frontend.port}}
 
-      - host: {{.Values.website.host}}
-        http:
-            paths:
-              - backend:
-                    serviceName: website-service
-                    servicePort: {{.Values.website.port}}
-      - host: www.{{.Values.website.host}}
-        http:
-            paths:
-              - backend:
-                    serviceName: website-service
-                    servicePort: {{.Values.website.port}}
+    - host: {{.Values.website.host}}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: website-service
+                port:
+                  number: {{.Values.website.port}}
+    - host: www.{{.Values.website.host}}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: website-service
+                port:
+                  number: {{.Values.website.port}}
 
 ---
 
@@ -56,16 +80,16 @@ spec:
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
-    name: blockedtodo-certificate
-    namespace: {{.Values.namespace}}
+  name: blockedtodo-certificate
+  namespace: {{.Values.namespace}}
 spec:
-    domains:
-        - {{.Values.backend.host}}
-        - www.{{.Values.backend.host}}
-        - {{.Values.frontend.host}}
-        - www.{{.Values.frontend.host}}
-        - {{.Values.website.host}}
-        - www.{{.Values.website.host}}
+  domains:
+    - {{.Values.backend.host}}
+    - www.{{.Values.backend.host}}
+    - {{.Values.frontend.host}}
+    - www.{{.Values.frontend.host}}
+    - {{.Values.website.host}}
+    - www.{{.Values.website.host}}
 {{- end}}
 
 ---
@@ -76,10 +100,10 @@ spec:
 apiVersion: networking.gke.io/v1
 kind: FrontendConfig
 metadata:
-    name: https-redirect
-    namespace: {{.Values.namespace}}
+  name: https-redirect
+  namespace: {{.Values.namespace}}
 spec:
-    sslPolicy: gke-ingress-ssl-policy
-    redirectToHttps:
-        enabled: true
+  sslPolicy: gke-ingress-ssl-policy
+  redirectToHttps:
+    enabled: true
 {{- end}}


### PR DESCRIPTION
Resources used:
- https://stackoverflow.com/questions/70464136/kubectl-apply-ingress-unknown-field-error
- https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122