### PR TITLE
Fix UPGRADE FAILED: unable to recognize "": no matches for kind "Fron…

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -97,7 +97,7 @@ spec:
 # For HTTP to HTTPS redirects, as per https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#https_redirect
 # Following this recipe: https://github.com/GoogleCloudPlatform/gke-networking-recipes/tree/main/ingress/single-cluster/ingress-https
 {{- if eq .Values.environment "production"}}
-apiVersion: networking.gke.io/v1
+apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
   name: https-redirect


### PR DESCRIPTION
…tendConfig" in version "networking.gke.io/v1"

Revert apiVersion of FrontendConfig for https redirects to v1beta1

As shown in https://github.com/GoogleCloudPlatform/gke-networking-recipes/tree/main/ingress/single-cluster/ingress-https