### PR TITLE
Remove /health backend endpoint.

### DIFF
--- a/services/backend/src/app.js
+++ b/services/backend/src/app.js
@@ -21,7 +21,6 @@ app.use(githubWebhooks);
 
 app.get('/', (req, res, next) => res.send('BlockedTODO Backend Server'));
 app.get('/ping', (req, res, next) => res.send('Pong!'));
-app.get('/health', (req, res, next) => res.send('OK'));
 
 app.use('/auth', authRouter);
 app.use('/github', githubRouter);


### PR DESCRIPTION
This is an attempt to debug the 502 error we've ben getting when calling backend.blockedtodo.com

Error: Server Error
The server encountered a temporary error and could not complete your request.