### PR TITLE
Set initial delay for backend probes to 10 minutes

### DIFF
--- a/helm/templates/backend.yaml
+++ b/helm/templates/backend.yaml
@@ -32,14 +32,14 @@ spec:
             port: 3000
           timeoutSeconds: 8
           failureThreshold: 4
-          initialDelaySeconds: 60
+          initialDelaySeconds: 600
         readinessProbe:
           httpGet:
             path: /health
             port: 3000
           timeoutSeconds: 8
           failureThreshold: 4
-          initialDelaySeconds: 60
+          initialDelaySeconds: 600
         env:
         - name: NODE_ENV
           value: {{.Values.environment}}


### PR DESCRIPTION
This is to see if the issue is just that we don't wait long enough for the backend to be available.

I don't think the application startup is the problem since we can see in the logs that the app does start in time. Maybe there is something with ports being open later however.